### PR TITLE
Bugfix for channelid_to_channelname and vice versa

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -576,13 +576,13 @@ class SlackBackend(ErrBot):
     def channelid_to_channelname(self, id_: str):
         """Convert a Slack channel ID to its channel name"""
         log.warning(f"get channel name from {id_}")
-        room = SlackRoom(self._webclient, channelid=id_, bot=self)
+        room = SlackRoom(self.slack_web, channelid=id_, bot=self)
         return room.channelname
 
     def channelname_to_channelid(self, name: str):
         """Convert a Slack channel name to its channel ID"""
         log.warning(f"get channel id from {name}")
-        room = SlackRoom(self._webclient, name=name, bot=self)
+        room = SlackRoom(self.slack_web, name=name, bot=self)
         return room.id
 
     def channels(


### PR DESCRIPTION
`channelid_to_channelname` and `channelname_to_channelid` were both using `self._webclient` which is never set (likely a remnant of an old variable?) instead of `self.slack_web`. This lead to: 

```
Traceback (most recent call last):
  File "/home/maf/dev/python/.envs/lebowski-slack/lib/python3.9/site-packages/errbot/plugin_manager.py", line 521, in activate_plugin
    self._activate_plugin(plugin, plugin_info)
  File "/home/maf/dev/python/.envs/lebowski-slack/lib/python3.9/site-packages/errbot/plugin_manager.py", line 476, in _activate_plugin
    plugin.callback_connect()
  File "/home/maf/dev/python/lebowski-slack/plugins/shared/shared.py", line 70, in callback_connect
    self.send(self.build_identifier("#test-lebowski"), "Lebowski started")
  File "/home/maf/dev/python/.envs/lebowski-slack/lib/python3.9/site-packages/errbot/botplugin.py", line 691, in build_identifier
    return self._bot.build_identifier(txtrep)
  File "/home/maf/dev/python/lebowski-slack/backends/err-backend-slackv3/slackv3.py", line 955, in build_identifier
    channelid = self.channelname_to_channelid(channelname)
  File "/home/maf/dev/python/lebowski-slack/backends/err-backend-slackv3/slackv3.py", line 585, in channelname_to_channelid
    room = SlackRoom(self._webclient, name=name, bot=self)
AttributeError: 'SlackBackend' object has no attribute '_webclient'
```