### PR TITLE
Replace deprecated method calls

### DIFF
--- a/_slack/room.py
+++ b/_slack/room.py
@@ -174,7 +174,6 @@ class SlackRoom(Room):
                 raise RoomError(e)
         self._id = None
 
-    # TODO: Update this method to use slacksdk.
     @property
     def exists(self):
         channels = self._bot.channels(joined_only=False, exclude_archived=False)
@@ -237,17 +236,17 @@ class SlackRoom(Room):
                 )
         return occupants
 
-    # TODO: Update this method to use slacksdk.
     def invite(self, *args):
         users = {
             user["name"]: user["id"]
             for user in self._webclient.api_call("users.list")["members"]
         }
+
         for user in args:
             if user not in users:
                 raise UserDoesNotExistError(f'User "{user}" not found.')
             log.info("Inviting %s into %s (%s)", user, self, self.id)
-            method = "groups.invite" if self.private else "channels.invite"
+            method = "conversations.invite"
             response = self._bot.api_call(
                 method,
                 data={"channel": self.id, "user": users[user]},

--- a/slackv3.py
+++ b/slackv3.py
@@ -41,7 +41,7 @@ try:
     from slack_sdk.web import WebClient
     from slackeventsapi import SlackEventAdapter
 except ImportError:
-    log.exception("Could not start the SlackSDK backend")
+    log.exception("Could not start the SlackV3 backend")
     log.fatal(
         "You need to install python modules in order to use the Slack backend.\n"
         "You can do `pip install errbot[slack-sdk]` to install them."
@@ -309,7 +309,7 @@ class SlackBackend(ErrBot):
                     log.debug(f"RTM event type {event_type} not supported.")
 
             log.info("Connecting to Slack RTM API")
-            self.slack_rtm.start()
+            self.slack_rtm.connect()
         else:
             # If the Application token is set, run in socket mode otherwise use Request URL.
             if self.app_token:

--- a/slackv3.py
+++ b/slackv3.py
@@ -1017,7 +1017,7 @@ class SlackBackend(ErrBot):
 
             ts = self._ts_for_message(msg)
 
-            self.slackweb.api_call(
+            self.api_call(
                 method,
                 data={"channel": to_channel_id, "timestamp": ts, "name": reaction},
             )


### PR DESCRIPTION
As mentioned here https://github.com/errbotio/errbot/issues/1545, `rtm.start` is deprecated in favour of `rtm.connect`