### PR TITLE
Add aclattr properties to Room class for ACL support. Fixes #61

### DIFF
--- a/_slack/room.py
+++ b/_slack/room.py
@@ -117,6 +117,8 @@ class SlackRoom(Room):
         """Return the ID of this room"""
         return self._cache["id"]
 
+    aclattr = id
+
     @property
     def channelid(self):
         """Return the Slack representation of the channel in the form <#CHANNELID|CHANNELNAME>"""


### PR DESCRIPTION
This PR is to add aclattr to the Room class to be used in errbot ACL processing.

This patch depends on https://github.com/errbotio/errbot/pull/1550 being merged.