### PR TITLE
Fix bot uid not found

### DIFF
--- a/_slack/person.py
+++ b/_slack/person.py
@@ -85,25 +85,21 @@ class SlackPerson(Person):
         if self._userid is None:
             raise ValueError("Unable to look up an undefined user id.")
 
-        isbot = False
-        if self._userid[0] == "B":
-            isbot = True
-
         # Fix error while looking up shorter bot uid
         if len(self._userid) <= 3:
             return
 
-        if not isbot:
-            res = self._webclient.users_info(user=self._userid)
-        else:
+        if self._userid[0] == "B":
             res = self._webclient.bots_info(bot=self._userid)
+        else:
+            res = self._webclient.users_info(user=self._userid)
 
         if res["ok"] is False:
             log.error(
                 f"Cannot find user with ID {self._userid}. Slack Error: {res['error']}"
             )
         else:
-            if isbot:
+            if "bot" in res:
                 self._user_info["display_name"] = res["bot"].get("name", "")
             else:
                 for attribute in ["real_name", "display_name", "email"]:

--- a/_slack/person.py
+++ b/_slack/person.py
@@ -88,7 +88,11 @@ class SlackPerson(Person):
         isbot = False
         if self._userid[0] == "B":
             isbot = True
-        
+
+        # Fix error while looking up shorter bot uid
+        if len(self._userid) <= 3:
+            return
+
         if not isbot:
             res = self._webclient.users_info(user=self._userid)
         else:
@@ -99,7 +103,7 @@ class SlackPerson(Person):
                 f"Cannot find user with ID {self._userid}. Slack Error: {res['error']}"
             )
         else:
-            if isbot:                
+            if isbot:
                 self._user_info["display_name"] = res["bot"].get("name", "")
             else:
                 for attribute in ["real_name", "display_name", "email"]:


### PR DESCRIPTION
If the slack "person" is a a bot, a different endpoint has to be used to get information, otherwise the API endpoint "users.info" will return an error saying "user_not_found".