### PR TITLE
Add ability to update slack messages

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -672,7 +672,7 @@ class SlackBackend(ErrBot):
                 log.debug("This is a divert to private message, sending it directly to the user.")
                 to_channel_id = self.get_im_channel(msg.to.userid)
         return to_humanreadable, to_channel_id
-    
+
     def send_message(self, msg):
         super().send_message(msg)
 

--- a/slackv3.py
+++ b/slackv3.py
@@ -728,7 +728,6 @@ class SlackBackend(ErrBot):
                 if "thread_ts" in msg.extras:
                     data["thread_ts"] = msg.extras["thread_ts"]
                     
-                    
                 if "ts" in msg.extras and current_ts_length > index:
                     # If a timestamp exists for the current chunk, update it - otherwise, send it as new
                     data["ts"] = msg.extras["ts"][index]


### PR DESCRIPTION
# What

* Add a method to update messages
* Alter send_message method so that if the message timestamps are present, it will update the message(s) instead

# Why

Updating messages is really handy, to communicate status, follow up with feedback, or replace some placeholder text while the bot works on an answer.

# Example usage
Here's a basic example of sending an initial message, doing some processing (in this case `sleep`ing) and then updating the original message to avoid clutter in a channel.

```python
@botcmd
def hello(self, msg, args):
    """Say hello to someone"""
    first_msg = self._bot.send_message(
        Message(
            to=msg.frm,
            body="Give me a moment while I get that for you!",
        )
    )

    time.sleep(10)

    first_msg.body = "Ah, here we go. The answer is 42"

    updated_msg = self._bot.update_message(first_msg)
```


# Misc 

Related to : 

* https://github.com/errbotio/err-backend-slackv3/issues/35
* https://github.com/errbotio/err-backend-slackv3/issues/37