### PR TITLE
Send cards to threads, when asked

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -826,6 +826,17 @@ class SlackBackend(ErrBot):
                 "link_names": "1",
                 "as_user": "true",
             }
+
+            if card.parent is not None:
+                # we are asked to reply to a specific thread.
+                try:
+                    data["thread_ts"] = self._ts_for_message(card.parent)
+                except KeyError:
+                    # Cannot reply to thread without a timestamp from the parent.
+                    log.exception(
+                        "The provided parent message is not a Slack message "
+                        "or does not contain a Slack timestamp."
+                    )
             try:
                 log.debug(f"Sending data:\n{data}")
                 self.slack_web.chat_postMessage(**data)


### PR DESCRIPTION
# What

* Change `send_card` method to include the thread timestamp when provided

# Why

Cards can be pretty big, it's nice to keep them limited to threads when appropriate.

# Example Usage

If the message it received was part of a thread, it will respond in a thread.

```python
@botcmd
def hello(self, msg, args):
    """Say hello to someone"""
    return_msg = Card(
        to=msg.frm,
        title="Hello, world",
        parent=msg.parent if msg.parent else None,
    )

    self._bot.send_card(return_msg)

```


Or if you wanted to default to sending a threaded message, you could make the parent the received message:

```python
@botcmd
def hello(self, msg, args):
    """Say hello to someone"""
    return_msg = Card(
        to=msg.frm,
        title="Hello, world",
        parent=msg
    )

    self._bot.send_card(return_msg)
``