### PR TITLE
Fix KeyError ts on sending message

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -712,7 +712,7 @@ class SlackBackend(ErrBot):
             log.debug(f"Message size: {len(body)}.")
 
             parts = self.prepare_message_body(body, self.message_size_limit)
-            current_ts_length = len(msg.extras["ts"])
+            current_ts_length = len(msg.extras.get("ts", ""))
 
             timestamps = []
             for index, part in enumerate(parts):


### PR DESCRIPTION
Fixes #78
```
Traceback (most recent call last):
  File "/home/errbot/backend-plugins/slackv3/slackv3.py", line 715, in send_message
    current_ts_length = len(msg.extras["ts"])
KeyError: 'ts'
```