### PR TITLE
Add tests for updating messages, and sending normal or ephemeral messages

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -673,7 +673,7 @@ class SlackBackend(ErrBot):
                 to_channel_id = self.get_im_channel(msg.to.userid)
         return to_humanreadable, to_channel_id
 
-    def send_message(self, msg):
+    def send_message(self, msg) -> Message:
         super().send_message(msg)
 
         if msg.parent is not None:

--- a/slackv3.py
+++ b/slackv3.py
@@ -766,7 +766,7 @@ class SlackBackend(ErrBot):
             
         return msg
 
-    def update_message(self, msg):
+    def update_message(self, msg) -> Message:
         if "ts" not in msg.extras or len(msg.extras["ts"]) <= 0:
             # If a timestamp wasn't provided, log an error and return the original message
             log.error(

--- a/slackv3.py
+++ b/slackv3.py
@@ -741,7 +741,9 @@ class SlackBackend(ErrBot):
                     result = self.slack_web.chat_postEphemeral(**data)
                 else:
                     result = self.slack_web.chat_postMessage(**data)
-                timestamps.append(result["ts"])
+
+                if "ts" in result:
+                    timestamps.append(result["ts"])
 
             if "ts" in msg.extras and current_ts_length > len(parts):
                 # If we have more timestamps than msg parts, delete the remaining timestamps

--- a/tests/slack_test.py
+++ b/tests/slack_test.py
@@ -220,6 +220,30 @@ SUCCESSFUL_EPHEMERAL_MESSAGE_RESPONSE = json.loads(
     """
 )
 
+EXAMPLE_UPDATE_MESSAGE = Message(
+    body="Here's a message for you",
+    to=MOCKED_PERSON,
+    extras={
+        'ts': ['1401383885.000061'],
+    }
+)
+
+# https://api.slack.com/methods/chat.postEphemeral#examples
+SUCCESSFUL_UPDATE_MESSAGE_RESPONSE = json.loads(
+    """
+{
+    "ok": true,
+    "channel": "C024BE91L",
+    "ts": "1502210682.580145",
+    "text": "Updated text you carefully authored",
+    "message": {
+        "text": "Updated text you carefully authored",
+        "user": "U34567890"
+    }
+}
+    """
+)
+
 
 class SlackTests(unittest.TestCase):
     def setUp(self):
@@ -523,3 +547,17 @@ class SlackTests(unittest.TestCase):
 
         # Ephemeral messages can't be updated, so should have no timestamps
         self.assertEqual(resp.extras['ts'], [])
+
+    def test_update_message(self):
+        self.slack.slack_web = MagicMock()
+        self.slack.slack_web.chat_update.return_value = SUCCESSFUL_UPDATE_MESSAGE_RESPONSE
+
+        # Mock an empty plugin manager (we're not testing plugins here)
+        mocked_plugin_manager = MagicMock()
+        mocked_plugin_manager.get_all_active_plugins.return_value = []
+        self.slack.attach_plugin_manager(mocked_plugin_manager)
+        
+        resp = self.slack.update_message(EXAMPLE_UPDATE_MESSAGE)
+
+        self.assertEqual(resp.body, EXAMPLE_UPDATE_MESSAGE.body)
+        self.assertEqual(len(resp.extras['ts']), 1)


### PR DESCRIPTION
# What

* Added tests for `send_message` and `update_message
* Fixed a small bug with ephemeral messages as they don't return a `ts` attribute like regular messages

# Why

Noticed there was a gap to filled with some tests, so figured I'd try and cover them. If there's anything that doesn't fit the status quo, let me know :)


# Coverage report

```
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/esmith/Documents/Personal/err-backend-slackv3
plugins: cov-3.0.0, pep8-1.0.6
collected 29 items

tests/slack_test.py ...........                                          [ 37%]
tests/_slack/markdown_test.py .                                          [ 41%]
tests/_slack/person_test.py ................                             [ 96%]
tests/_slack/room_test.py .                                              [100%]

---------- coverage: platform darwin, python 3.9.12-final-0 ----------
Name                            Stmts   Miss  Cover
---------------------------------------------------
_slack/__init__.py                  0      0   100%
_slack/lib.py                       8      2    75%
_slack/markdown.py                 17      0   100%
_slack/person.py                   89      6    93%
_slack/room.py                    221    133    40%
slackv3.py                        553    313    43%
tests/_slack/markdown_test.py      13      0   100%
tests/_slack/person_test.py        92      0   100%
tests/_slack/room_test.py          13      0   100%
tests/conftest.py                   3      0   100%
tests/slack_test.py               171      6    96%
---------------------------------------------------
TOTAL                            1180    460    61%


============================== 29 passed in 0.87s ==============================
```