### PR TITLE
Allow supplying raw attachments/blocks for messages

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -748,6 +748,10 @@ class SlackBackend(ErrBot):
                     "as_user": "true",
                 }
 
+                if "attachments" in msg.extras and index == len(parts) - 1:
+                    # If attachments provided, and it's the last part of the mssage
+                    data['attachments'] = json.dumps(msg.extras["attachments"])
+
                 # Keep the thread_ts to answer to the same thread.
                 if "thread_ts" in msg.extras:
                     data["thread_ts"] = msg.extras["thread_ts"]

--- a/slackv3.py
+++ b/slackv3.py
@@ -747,16 +747,16 @@ class SlackBackend(ErrBot):
                     "link_names": "1",
                     "as_user": "true",
                 }
-                
+
                 if index == len(parts) - 1:
                     # Only add attachments/blocks if it's the last message, to avoid duplication
                     if "attachments" in msg.extras:
                         # If attachments are provided, and it's the last part of the mssage
-                        data['attachments'] = json.dumps(msg.extras["attachments"])
+                        data["attachments"] = json.dumps(msg.extras["attachments"])
 
                     if "blocks" in msg.extras:
                         # If blocksare provided, and it's the last part of the mssage
-                        data['blocks'] = json.dumps(msg.extras["blocks"])
+                        data["blocks"] = json.dumps(msg.extras["blocks"])
 
                 # Keep the thread_ts to answer to the same thread.
                 if "thread_ts" in msg.extras:

--- a/slackv3.py
+++ b/slackv3.py
@@ -747,10 +747,16 @@ class SlackBackend(ErrBot):
                     "link_names": "1",
                     "as_user": "true",
                 }
+                
+                if index == len(parts) - 1:
+                    # Only add attachments/blocks if it's the last message, to avoid duplication
+                    if "attachments" in msg.extras:
+                        # If attachments are provided, and it's the last part of the mssage
+                        data['attachments'] = json.dumps(msg.extras["attachments"])
 
-                if "attachments" in msg.extras and index == len(parts) - 1:
-                    # If attachments provided, and it's the last part of the mssage
-                    data['attachments'] = json.dumps(msg.extras["attachments"])
+                    if "blocks" in msg.extras:
+                        # If blocksare provided, and it's the last part of the mssage
+                        data['blocks'] = json.dumps(msg.extras["blocks"])
 
                 # Keep the thread_ts to answer to the same thread.
                 if "thread_ts" in msg.extras:


### PR DESCRIPTION
# What

* Add functionality for adding attachments/blocks to slack messages

# Why 

The default errbot Card makes it a little hard to use slack's in-built block builder, so I was hoping to add a way to bypass the card usage to supply a raw format of attachments/blocks as a workaround until we work out maybe a better way to use cards for slack's UI blocks :) 

# Example Usage

```python
from slack_sdk.models.blocks import SectionBlock, TextObject
from errbot.backends.base import Message


[...]
@botcmd
def hello(self, msg, args):
    """Say hello to someone"""
    msg.body = "Using the sent message to shorten the code example"
    msg.extras['attachments'] = [{
        'color': '5F4B48',
        'fallback': 'Help text for: Bot plugin',
        'footer': 'For these commands: `help Bot`',
        'text': 'General commands to do with the ChatOps bot',
        'title': 'Bot'
    },{
        'color': 'FAF5F5',
        'fallback': 'Help text for: Example plugin',
        'footer': 'For these commands: `help Example`',
        'text': 'This is a very basic plugin to try out your new installation and get you started.\n Feel free to tweak me to experiment with Errbot.\n You can find me in your init directory in the subdirectory plugins.',
        'title': 'Example'
    }]

    self._bot.send_message(msg)


    # Example with the blocks SDK
    msg = Message()
    msg.extras['blocks'] = [
        SectionBlock(
            text=TextObject(
                text="Welcome to Slack! :wave: We're so glad you're here. :blush:\n\n",
                type="mrkdwn"
            )
        ).to_dict()
    ]
    self._bot.send_message(msg)
```