### PR TITLE
Link documentation to official errbot site

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -41,21 +41,21 @@ jobs:
         tox -e py
 
     - name: Check Distribution
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version }} == '3.9'
       run: |
         tox -e dist-check
 
     - name: Codestyle
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version }} == '3.9'
       run: |
         tox -e codestyle
 
     - name: Lint - sort
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version }} == '3.9'
       run: |
         tox -e sort
 
     - name: Security
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version }} == '3.9'
       run: |
         tox -e security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,30 +23,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
  - Ensure ephemeral messages return a ts attribute. #81 (@TheJokersThief)
 
-## [0.2.1] 2022-10-02
-### Added
- - Send cards to threads, when requested. #76 (@TheJokersThief)
- - Ability to update slack messages. #75 (@TheJokersThief)
- - Allow supplying raw attachments/blocks for messages. #83 (@TheJokersThief)
-
-### Changed
- - refactored repository for setting it up as a pypi package. #82, #89 (@sijis)
-
-### Fixed
- - Ensure ephemeral messages return a ts attribute. #81 (@TheJokersThief)
-
-## [0.2.1] 2022-10-02
-### Added
- - Send cards to threads, when requested. #76 (@TheJokersThief)
- - Ability to update slack messages. #75 (@TheJokersThief)
- - Allow supplying raw attachments/blocks for messages. #83 (@TheJokersThief)
-
-### Changed
- - refactored repository for setting it up as a pypi package. #82, #89 (@sijis)
-
-### Fixed
- - Ensure ephemeral messages return a ts attribute. #81 (@TheJokersThief)
-
 ## [0.2.0] 2022-09-22
 ### Added
  -  Ability to update slack messages. #75 (@TheJokersThief)

--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ See the [slackv3 documentation](https://err-backend-slackv3.readthedocs.io/en/la
 ## Support
 
 If you need help for an `err-backend-slackv3` problem, open an issue at [github repository](https://github.com/errbotio/err-backend-slackv3)
-

--- a/README.md
+++ b/README.md
@@ -4,14 +4,51 @@
 
 Slack Events and Real Time Messaging backend for Errbot.
 
+## Quick Start
+
+It is recommended to install errbot into a Python virtual environment.  The steps are as follows:
+_Note: The examples assume the virtual environment is created as `/opt/errbot` but you can adapt this path to your needs._
+
+1. Create and activate the virtual environment.
+
+```
+python3 -m venv /opt/errbot
+. /opt/errbot/bin/activate
+```
+
+2. Install errbot and slackv3.
+```
+pip install errbot[slack]
+```
+
+3. Initialise errbot.
+```
+errbot --init
+```
+
+4. Edit `config.py` to configure the backend with the correct Slack credentials. (See the official documentation of details on how to configure the backend for RTM vs Events)
+```
+BACKEND = 'SlackV3'
+BOT_IDENTITY = {
+    'token': 'xoxb-000000000000-000000000000-xxxxxxxxxxxxxxxxxxxxxxxx',
+    #'signing_secret': "xxxxxx",
+    #'app_token': "xxxxx"
+}
+```
+
+5. Start errbot
+```
+errbot -c config.py
+```
+
 ## Documentation
 
 See the [slackv3 documentation](https://err-backend-slackv3.readthedocs.io/en/latest/) for:
  - Installation
- - Configuraiton
+ - Configuration
  - User guide
  - Developer guide
 
 ## Support
 
-If you need help for an `err-backend-slackv3` problem, open an issue at [github repository](https://github.com/errbotio/err-backend-slackv3)
+If you need help for an `errbot-backend-slackv3` problem, open an issue at [github repository](https://github.com/errbotio/err-backend-slackv3)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "errbot-backend-slackv3"
+copyright = "2019-20223, errbot-backend-slackv3 contributors"
+author = "errbot-backend-slackv3 contributors"
+
+# The full version, including alpha/beta/rc tags
+release = "0.2.1"
+
+
+# -- General configuration ---------------------------------------------------
+
+master_doc = "index"
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = []
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+# html_theme = 'alabaster'
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]


### PR DESCRIPTION
To avoid duplicating maintenance effort between the readme and the official documentation, the README will now link to errbot's official documentation.