### PR TITLE
Fix uploading to channels

### DIFF
--- a/src/slackv3/slackv3.py
+++ b/src/slackv3/slackv3.py
@@ -792,7 +792,7 @@ class SlackBackend(ErrBot):
         try:
             stream.accept()
             resp = self.slack_web.files_upload(
-                channels=stream.identifier.channelid, filename=stream.name, file=stream
+                channels=stream.identifier.id, filename=stream.name, file=stream
             )
             if resp.get("ok"):
                 stream.success()


### PR DESCRIPTION
`send_stream_request`  returns `channel_not_found`  when sending to a channel.  This is because Slack expects _just_ the channel id, not the form `<#CHANNELID|CHANNELNAME>` 