### PR TITLE
switched files_upload api call (end of life) to files_upload_v2

### DIFF
--- a/src/slackv3/slackv3.py
+++ b/src/slackv3/slackv3.py
@@ -810,8 +810,8 @@ class SlackBackend(ErrBot):
         """
         try:
             stream.accept()
-            resp = self.slack_web.files_upload(
-                channels=stream.identifier.channelid, filename=stream.name, file=stream
+            resp = self.slack_web.files_upload_v2(
+                channel=stream.identifier.channelid, filename=stream.name, file=stream
             )
             if resp.get("ok"):
                 stream.success()


### PR DESCRIPTION
Slack has deprecated the files_upload api call in favor of files.getUploadURLExternal files.completeUploadExternal

Docs here: https://api.slack.com/methods/files.upload#markdown

files_upload_v2 is the replacement function in the python sdk:

Docs here: https://tools.slack.dev/python-slack-sdk/api-docs/slack_sdk/#slack_sdk.WebClient.files_upload_v2